### PR TITLE
preflight support added

### DIFF
--- a/app/controllers/Application.java
+++ b/app/controllers/Application.java
@@ -37,6 +37,15 @@ public class Application extends Controller {
         render();
     }
 
+    public static void options(String url, final String callback) {
+        response().setHeader("Access-Control-Allow-Origin", "*");
+        response().setHeader("Allow", "*");
+        response().setHeader("Access-Control-Allow-Methods", "POST, GET, PUT, DELETE, OPTIONS");
+        response().setHeader("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept, Referer, User-Agent");
+
+        return ok();
+    }
+
     public static void get(String url, final String callback) {
         final String encodedUrl = UriEncoder.encode(url).replace("%3F", "?");
         F.Promise<WS.HttpResponse> remoteCall = WS.url(encodedUrl).getAsync();

--- a/conf/routes
+++ b/conf/routes
@@ -15,6 +15,7 @@ GET     /favicon.ico                            404
 GET     /public/                                staticDir:public
 
 GET     /{action}                               Application.{action}
+OPTIONS /{action}                               Application.{action}
 
 # Catch all
 *       /{controller}/{action}                  {controller}.{action}


### PR DESCRIPTION
When I use this I got stuck with Chrome Pre-flight call which is doing a HTTP OPTIONS call to check whenever the endpoint has or not the Access-Control-Allow-Origin header.

You need to support also that method to make it work, otherwise we're still stuck with CORS issues.

`$.getJSON('https://allorigins.me/get?method=raw&url=https%3A%2F%2Fipapi.co%2Fjson')`

{readyState: 1, getResponseHeader: ƒ, getAllResponseHeaders: ƒ, setRequestHeader: ƒ, overrideMimeType: ƒ, …}

> Response to preflight request doesn't pass access control check: No 'Access-Control-Allow-Origin' header is present on the requested resource. Origin 'http://localhost is therefore not allowed access.
